### PR TITLE
Add a round() to the Advanced Simulator Stats percentages.

### DIFF
--- a/sbbbattlesim/stats/cinderella_quest_completion_chance.py
+++ b/sbbbattlesim/stats/cinderella_quest_completion_chance.py
@@ -24,4 +24,4 @@ class StatType(StatBase):
 
     @staticmethod
     def merge(stats: typing.List[typing.Union[str, int, float]]):
-        return (sum(stats) / len(stats)) * 100
+        return round((sum(stats) / len(stats)) * 100, 3)

--- a/sbbbattlesim/stats/egg_break_chance.py
+++ b/sbbbattlesim/stats/egg_break_chance.py
@@ -21,4 +21,4 @@ class StatType(StatBase):
 
     @staticmethod
     def merge(stats: typing.List[typing.Union[str, int, float]]):
-        return (sum(stats) / len(stats)) * 100
+        return round((sum(stats) / len(stats)) * 100, 3)

--- a/sbbbattlesim/stats/lancelot_quest_completion_chance.py
+++ b/sbbbattlesim/stats/lancelot_quest_completion_chance.py
@@ -17,4 +17,4 @@ class StatType(StatBase):
 
     @staticmethod
     def merge(stats: typing.List[typing.Union[str, int, float]]):
-        return (sum(stats) / len(stats)) * 100
+        return round((sum(stats) / len(stats)) * 100, 3)

--- a/sbbbattlesim/stats/poly_woggle_slay.py
+++ b/sbbbattlesim/stats/poly_woggle_slay.py
@@ -19,4 +19,4 @@ class StatType(StatBase):
 
     @staticmethod
     def merge(stats: typing.List[typing.Union[str, int, float]]):
-        return (sum(stats) / len(stats)) * 100
+        return round((sum(stats) / len(stats)) * 100, 3)

--- a/sbbbattlesim/stats/prize_pig_survival_rate.py
+++ b/sbbbattlesim/stats/prize_pig_survival_rate.py
@@ -17,4 +17,4 @@ class StatType(StatBase):
 
     @staticmethod
     def merge(stats: typing.List[typing.Union[str, int, float]]):
-        return (sum(stats) / len(stats)) * 100
+        return round((sum(stats) / len(stats)) * 100, 3)


### PR DESCRIPTION
The default floats were _super_ long.
Added a round((object), 3) to each of the /sbbbattlesim/stats/* that have percentages that need rounding.
Maybe it's not something that should be deployed, but all my buddies said it was weird, and I kind of agree.